### PR TITLE
Update mupdf dependency source and branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,12 @@ optional = true
 # For mupdf feature
 
 [dependencies.mupdf]
-git = "https://github.com/jackpot51/mupdf-rs"
-branch = "0.5"
+git = "https://github.com/messense/mupdf-rs"
+branch = "main"
+optional = true
+ 
+ [target.'cfg(unix)'.dependencies]
+
 optional = true
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Update dependency to point to https://github.com/messense/mupdf-rs main branch.
This allows cosmic-reader to build and it allows it also to run as well.